### PR TITLE
brew-cask is not a brew formula

### DIFF
--- a/api/install/cask.sh
+++ b/api/install/cask.sh
@@ -10,7 +10,6 @@ echo
 
 # Install Caskroom
 brew tap caskroom/cask
-brew install brew-cask
 brew tap caskroom/versions
 
 applications_to_install=(


### PR DESCRIPTION
If you run `brew install brew-cask` you'll see an error. It's wrong and not needed, installation is done with the previous tap.